### PR TITLE
Install pipstrap to pin setuptools/pip/wheels

### DIFF
--- a/core/Dockerfile
+++ b/core/Dockerfile
@@ -21,6 +21,7 @@ RUN mkdir -p src \
  && tar xf certbot-${CERTBOT_VERSION}.tar.gz \
  && cp certbot-${CERTBOT_VERSION}/CHANGELOG.md certbot-${CERTBOT_VERSION}/README.rst src/ \
  && cp certbot-${CERTBOT_VERSION}/letsencrypt-auto-source/pieces/dependency-requirements.txt . \
+ && cp certbot-${CERTBOT_VERSION}/letsencrypt-auto-source/pieces/pipstrap.py . \
  && cp -r certbot-${CERTBOT_VERSION}/tools tools \
  && cp -r certbot-${CERTBOT_VERSION}/acme src/acme \
  && cp -r certbot-${CERTBOT_VERSION}/certbot src/certbot \
@@ -45,6 +46,7 @@ RUN apk add --no-cache --virtual .build-deps \
         openssl-dev \
         musl-dev \
         libffi-dev \
+    && python pipstrap.py \
     && pip install -r dependency-requirements.txt \
     && pip install --no-cache-dir --no-deps \
         --editable src/acme \


### PR DESCRIPTION
So, setuptools broke the installation setup, by removing a deprecated API that is still used by some of our dependencies (see https://github.com/pypa/setuptools/issues/2017)

This PR fixes the Docker build by using pipstrap to pin pip/setuptools/wheels, like it is done in several critical places (certbot-auto, ...).

An issue in certbot is opened to fix more generally the problem in most recent versions of setuptools: https://github.com/certbot/certbot/issues/7976